### PR TITLE
Removes top-level imports of pytest plugin.

### DIFF
--- a/pydantic_factories/__init__.py
+++ b/pydantic_factories/__init__.py
@@ -8,7 +8,6 @@ from .extensions import (
 )
 from .factory import ModelFactory
 from .fields import Ignore, PostGenerated, Require, Use
-from .plugins import register_fixture
 from .protocols import AsyncPersistenceProtocol, SyncPersistenceProtocol
 
 __all__ = [
@@ -24,5 +23,4 @@ __all__ = [
     "SyncPersistenceProtocol",
     "Use",
     "PostGenerated",
-    "register_fixture",
 ]

--- a/pydantic_factories/plugins/__init__.py
+++ b/pydantic_factories/plugins/__init__.py
@@ -1,3 +1,0 @@
-from .pytest_plugin import register_fixture
-
-__all__ = ["register_fixture"]


### PR DESCRIPTION
Pytest is generally unavailable when the library is used outside of testing context.

Closes #77