### PR TITLE
Annotates `DataclassProtocol.__dataclass_fields__` as `ClassVar`.

### DIFF
--- a/pydantic_factories/protocols.py
+++ b/pydantic_factories/protocols.py
@@ -1,5 +1,5 @@
 # pylint: disable=unnecessary-ellipsis
-from typing import Any, Dict, List, TypeVar, Union
+from typing import Any, ClassVar, Dict, List, TypeVar, Union
 
 from pydantic import BaseModel
 from typing_extensions import Protocol
@@ -8,7 +8,7 @@ from typing_extensions import Protocol
 # According to https://github.com/python/cpython/blob/main/Lib/dataclasses.py#L1213
 # having __dataclass_fields__ is enough to identity a dataclass.
 class DataclassProtocol(Protocol):
-    __dataclass_fields__: Dict[str, Any]
+    __dataclass_fields__: ClassVar[Dict[str, Any]]
 
 
 T = TypeVar("T", bound=Union[BaseModel, DataclassProtocol])


### PR DESCRIPTION
All the tests and type checking still passes, is this likely to affect anything downstream from this lib?

Closes #88