### PR TITLE
Fix doc-string typo in ModelFactory.build

### DIFF
--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -689,8 +689,8 @@ class ModelFactory(ABC, Generic[T]):  # noqa: B024
         """builds an instance of the factory's __model__
 
         Args:
-            factory_use_construct: A boolea that determines whether validations will be made when instantiating the
-                model. this is supported only for pydantic models.
+            factory_use_construct: A boolean that determines whether validations will be made when instantiating the
+                model. This is supported only for pydantic models.
             **kwargs: Any kwargs. If field names are set in kwargs, their values will be used.
 
         Returns:


### PR DESCRIPTION
Found some typos when debug.