### PR TITLE
Fix factories not allowing to build when models have fields with similar keys to `ModelFactory` fields.

### DIFF
--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -707,7 +707,7 @@ class ModelFactory(ABC, Generic[T]):
                 field_name = model_field.alias
 
             if cls.should_set_field_value(field_name, model_field, **kwargs):
-                if hasattr(cls, field_name):
+                if field_name not in dir(ModelFactory) and hasattr(cls, field_name):
                     value = getattr(cls, field_name)
                     if isinstance(value, PostGenerated):
                         generate_post[field_name] = value

--- a/tests/test_factory_build.py
+++ b/tests/test_factory_build.py
@@ -113,3 +113,13 @@ def test_build_instance_by_field_name_with_allow_population_by_field_name_flag()
 
     instance = MyFactory.build(special_field="some")
     assert instance.aliased_field == "some"
+
+
+def test_build_model_with_fields_named_like_factory_fields() -> None:
+    class C(BaseModel):
+        batch: int
+
+    class CFactory(ModelFactory):
+        __model__ = C
+
+    assert CFactory.build()


### PR DESCRIPTION
This PR resolves #92 