### PR TITLE
Replace Xeger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,16 +7,22 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    env:
-      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - uses: pre-commit/action@v3.0.0
+      - name: Install Pre-Commit
+        run: python -m pip install pre-commit && pre-commit install
+      - name: Load cached Pre-Commit Dependencies
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Execute Pre-Commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
   test:
-    needs: validate
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -63,7 +69,9 @@ jobs:
           name: coverage-xml
           path: coverage.xml
   sonar:
-    needs: test
+    needs:
+      - test
+      - validate
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -81,25 +89,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   codeql:
-    needs: test
+    needs:
+      - test
+      - validate
     runs-on: ubuntu-latest
     permissions:
       security-events: write
     steps:
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: python
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
+      - name: Initialize CodeQL With Dependencies
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        uses: github/codeql-action/init@v2
+      - name: Initialize CodeQL Without Dependencies
+        if: github.event_name == 'pull_request'
+        uses: github/codeql-action/init@v2
         with:
-          path: .venv
-          key: v1-venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            v1-venv-${{ runner.os }}-${{ matrix.python-version }}
-            v1-venv-${{ runner.os }}
+          setup-python-dependencies: false
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: "3.11"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
@@ -5,12 +7,13 @@ repos:
       - id: check-ast
       - id: check-case-conflict
       - id: check-merge-conflict
+      - id: check-toml
       - id: debug-statements
       - id: end-of-file-fixer
-        exclude: "\\.idea/(.)*"
+      - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -73,7 +76,6 @@ repos:
             "flake8-noqa",
             "flake8-return",
             "flake8-secure-coding-standard",
-            "flake8-eradicate",
             "flake8-encodings",
             "flake8-use-fstring",
             "flake8-use-pathlib",
@@ -82,13 +84,6 @@ repos:
     rev: v0.4.0
     hooks:
       - id: flake8-markdown
-  - repo: https://github.com/dosisod/refurb
-    rev: v1.4.0
-    hooks:
-      - id: refurb
-        args: [--ignore, "120", --ignore, "128"]
-        additional_dependencies:
-          [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie, xeger]
   - repo: https://github.com/pycqa/pylint
     rev: "v2.15.5"
     hooks:
@@ -102,11 +97,11 @@ repos:
     hooks:
       - id: mypy
         exclude: "extension"
-        args: [--show-traceback, --pdb]
+
         additional_dependencies:
           [pydantic, faker, pytest, hypothesis, xeger, odmantic, ormar, beanie]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.277
+    rev: v1.1.278
     hooks:
       - id: pyright
         exclude: "extension"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         exclude: "test_*"
         args: ["--unsafe-load-any-extension=y"]
         additional_dependencies:
-          [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie, xeger]
+          [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.982"
     hooks:
@@ -99,11 +99,11 @@ repos:
         exclude: "extension"
 
         additional_dependencies:
-          [pydantic, faker, pytest, hypothesis, xeger, odmantic, ormar, beanie]
+          [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie]
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.278
     hooks:
       - id: pyright
         exclude: "extension"
         additional_dependencies:
-          [pydantic, faker, pytest, hypothesis, xeger, odmantic, ormar, beanie]
+          [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 [1.4.0]
 
-- replace `exrex` with `xeger` due to licensing issues.
+- replace `exrex` with `generate` due to licensing issues.
 
 [1.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+[1.14.0]
+
+- replace `Xeger` with local port to generate regexes.
+- update `BeaniePlugin` to support ID.
+
 [1.13.0]
 
 - fix `ModelFactory` mistaking model fields with names identical to factory methods to be factory fields.
@@ -84,7 +89,7 @@
 
 [1.4.0]
 
-- replace `exrex` with `generate` due to licensing issues.
+- replace `exrex` with `xeger` due to licensing issues.
 
 [1.3.0]
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,3 @@ warn_untyped_fields = True
 
 [mypy-tests.typing_test_strict]
 disallow_any_generics = True
-
-[mypy-xeger.*]
-ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.0.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -91,7 +91,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "15.1.1"
+version = "15.1.3"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = false
@@ -115,7 +115,7 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pyt
 
 [[package]]
 name = "hypothesis"
-version = "6.56.3"
+version = "6.56.4"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -123,7 +123,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=19.2.0"
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -144,7 +144,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.5)"]
 
 [[package]]
 name = "identify"
-version = "2.5.7"
+version = "2.5.8"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -420,7 +420,7 @@ docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sp
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "xeger"
+name = "generate"
 version = "0.3.5"
 description = "A library for generating random strings from a valid regular expression."
 category = "main"
@@ -522,24 +522,24 @@ email-validator = [
     {file = "email_validator-1.3.0.tar.gz", hash = "sha256:553a66f8be2ec2dea641ae1d3f29017ab89e9d603d4a25cdaac39eefa283d769"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
+    {file = "exceptiongroup-1.0.0.tar.gz", hash = "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"},
 ]
 faker = [
-    {file = "Faker-15.1.1-py3-none-any.whl", hash = "sha256:096c15e136adb365db24d8c3964fe26bfc68fe060c9385071a339f8c14e09c8a"},
-    {file = "Faker-15.1.1.tar.gz", hash = "sha256:a741b77f484215c3aab2604100669657189548f440fcb2ed0f8b7ee21c385629"},
+    {file = "Faker-15.1.3-py3-none-any.whl", hash = "sha256:bd922a6ad210bb96a5b31987e10918851131c9670429172d5bfb3a5ede238a79"},
+    {file = "Faker-15.1.3.tar.gz", hash = "sha256:1bfb1b447cd45169a74a09f821cee47f51548508b62a29f6dfdab1d001d448a4"},
 ]
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
     {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.56.3-py3-none-any.whl", hash = "sha256:802d236d03dbd54e0e1c55c0daa2ec41aeaadc87a4dcbb41421b78bf3f7a7789"},
-    {file = "hypothesis-6.56.3.tar.gz", hash = "sha256:15dae5d993339aefa57e00f5cb5a5817ff300eeb661d96d1c9d094eb62b04c9a"},
+    {file = "hypothesis-6.56.4-py3-none-any.whl", hash = "sha256:67950103ee930c66673494b3671474a083ea71f1ebe8f0ff849ba8ad5317772d"},
+    {file = "hypothesis-6.56.4.tar.gz", hash = "sha256:313bc1c0f377ec6c98815d3237a69add7558eadee4effe4ed613d0ba36513a52"},
 ]
 identify = [
-    {file = "identify-2.5.7-py2.py3-none-any.whl", hash = "sha256:7a67b2a6208d390fd86fd04fb3def94a3a8b7f0bcbd1d1fcd6736f4defe26390"},
-    {file = "identify-2.5.7.tar.gz", hash = "sha256:5b8fd1e843a6d4bf10685dd31f4520a7f1c7d0e14e9bc5d34b1d6f111cabc011"},
+    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
+    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -639,6 +639,13 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -694,8 +701,8 @@ virtualenv = [
     {file = "virtualenv-20.16.6-py3-none-any.whl", hash = "sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108"},
     {file = "virtualenv-20.16.6.tar.gz", hash = "sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e"},
 ]
-xeger = [
-    {file = "xeger-0.3.5.tar.gz", hash = "sha256:2a91341fc2c814b27917b8bd24e8d212c8a3b904d98e9a6703d27484c2cb0f82"},
+generate = [
+    {file = "generate-0.3.5.tar.gz", hash = "sha256:2a91341fc2c814b27917b8bd24e8d212c8a3b904d98e9a6703d27484c2cb0f82"},
 ]
 zipp = [
     {file = "zipp-3.10.0-py3-none-any.whl", hash = "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1"},

--- a/pydantic_factories/constraints/strings.py
+++ b/pydantic_factories/constraints/strings.py
@@ -1,12 +1,11 @@
-from typing import TYPE_CHECKING, Any, Optional, Pattern, Tuple, Union, cast
-
-from xeger import Xeger
+from typing import TYPE_CHECKING, Any, Optional, Pattern, Tuple, Union
 
 from pydantic_factories.exceptions import ParameterError
 from pydantic_factories.value_generators.primitives import (
     create_random_bytes,
     create_random_string,
 )
+from pydantic_factories.value_generators.regex import RegexFactory
 
 if TYPE_CHECKING:
     from pydantic import ConstrainedBytes, ConstrainedStr
@@ -42,7 +41,7 @@ def handle_constrained_bytes(field: "ConstrainedBytes") -> bytes:
 
 def handle_constrained_string(field: "ConstrainedStr", random_seed: Optional[int]) -> str:
     """Handles ConstrainedStr and Fields with string constraints."""
-    regex_factory = Xeger(seed=random_seed)
+    regex_factory = RegexFactory(seed=random_seed)
     min_length, max_length, lower_case = parse_constrained_string_or_bytes(field)
 
     if max_length == 0:
@@ -55,12 +54,12 @@ def handle_constrained_string(field: "ConstrainedStr", random_seed: Optional[int
     if isinstance(regex, Pattern):
         regex = regex.pattern
 
-    result = regex_factory.xeger(regex)
+    result = regex_factory(regex)
     if min_length:
         while len(result) < min_length:
-            result += regex_factory.xeger(regex)
+            result += regex_factory(regex)
 
     if max_length and len(result) > max_length:
         result = result[:max_length]
 
-    return cast("str", result.lower() if lower_case else result)
+    return result.lower() if lower_case else result

--- a/pydantic_factories/value_generators/regex.py
+++ b/pydantic_factories/value_generators/regex.py
@@ -1,0 +1,135 @@
+"""The code in this files is adapted from
+https://github.com/crdoconnor/xeger/blob/master/xeger/xeger.py Which in turn
+adapted it from https://bitbucket.org/leapfrogdevelopment/rstr/
+
+Copyright (C) 2015, Colm O'Connor
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Leapfrog Direct Response, LLC, including
+      its subsidiaries and affiliates nor the names of its
+      contributors, may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL LEAPFROG DIRECT
+RESPONSE, LLC, INCLUDING ITS SUBSIDIARIES AND AFFILIATES, BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from itertools import chain
+from random import Random
+from sre_parse import SubPattern, parse  # pylint: disable=W4901,E0611
+from string import (
+    ascii_letters,
+    ascii_lowercase,
+    ascii_uppercase,
+    digits,
+    printable,
+    punctuation,
+    whitespace,
+)
+from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
+
+_alphabets = {
+    "printable": printable,
+    "letters": ascii_letters,
+    "uppercase": ascii_uppercase,
+    "lowercase": ascii_lowercase,
+    "digits": digits,
+    "punctuation": punctuation,
+    "nondigits": ascii_letters + punctuation,
+    "nonletters": digits + punctuation,
+    "whitespace": whitespace,
+    "nonwhitespace": printable.strip(),
+    "normal": ascii_letters + digits + " ",
+    "word": ascii_letters + digits + "_",
+    "nonword": "".join(set(printable).difference(ascii_letters + digits + "_")),
+    "postalsafe": ascii_letters + digits + " .-#/",
+    "urlsafe": ascii_letters + digits + "-._~",
+    "domainsafe": ascii_letters + digits + "-",
+}
+
+_categories = {
+    "category_digit": _alphabets["digits"],
+    "category_not_digit": _alphabets["nondigits"],
+    "category_space": _alphabets["whitespace"],
+    "category_not_space": _alphabets["nonwhitespace"],
+    "category_word": _alphabets["word"],
+    "category_not_word": _alphabets["nonword"],
+}
+
+
+class RegexFactory:
+    def __init__(self, limit: int = 10, seed: Optional[int] = None) -> None:
+        self._limit = limit
+        self._cache: Dict[str, Any] = {}
+        self._random = Random(x=seed)
+
+        self._cases = {
+            "literal": chr,
+            "not_literal": lambda x: self._random.choice(printable.replace(chr(x), "")),
+            "at": lambda x: "",
+            "in": self._handle_in,
+            "any": lambda x: self._random.choice(printable.replace("\n", "")),
+            "range": lambda x: [chr(i) for i in range(x[0], x[1] + 1)],
+            "category": lambda x: _categories[str(x).lower()],
+            "branch": lambda x: "".join(self._handle_state(i) for i in self._random.choice(x[1])),
+            "subpattern": self._handle_group,
+            "assert": lambda x: "".join(self._handle_state(i) for i in x[1]),
+            "assert_not": lambda x: "",
+            "groupref": lambda x: self._cache[x],
+            "min_repeat": lambda x: self._handle_repeat(*x),
+            "max_repeat": lambda x: self._handle_repeat(*x),
+            "negate": lambda x: [False],
+        }
+
+    def __call__(self, string_or_regex: Union[str, Pattern]) -> str:
+        pattern = string_or_regex.pattern if isinstance(string_or_regex, Pattern) else string_or_regex
+        parsed = parse(pattern)
+        result = self._build_string(parsed)
+        self._cache.clear()
+        return result  # noqa: R504
+
+    def _build_string(self, parsed: SubPattern) -> str:
+        return "".join([self._handle_state(state) for state in parsed])  # type: ignore
+
+    def _handle_state(self, state: Tuple[SubPattern, Tuple[Any, ...]]) -> Any:
+        opcode, value = state
+        return self._cases[str(opcode).lower()](value)  # type: ignore
+
+    def _handle_group(self, value: Tuple[Any, ...]) -> str:
+        result = "".join(self._handle_state(i) for i in value[3])
+        if value[0]:
+            self._cache[value[0]] = result
+        return result
+
+    def _handle_in(self, value: Tuple[Any, ...]) -> Any:
+        candidates = list(chain(*(self._handle_state(i) for i in value)))
+        if candidates and candidates[0] is False:
+            candidates = list(set(printable).difference(candidates[1:]))
+            return self._random.choice(candidates)
+        return self._random.choice(candidates)
+
+    def _handle_repeat(self, start_range: int, end_range: Any, value: SubPattern) -> str:
+        result: List[str] = []
+        end_range = min((end_range, self._limit))
+
+        for i in range(self._random.randint(start_range, max(start_range, end_range))):
+            result.append("".join(self._handle_state(i) for i in list(value)))  # type: ignore
+
+        return "".join(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ python = ">=3.7,<4.0"
 faker = "*"
 pydantic = ">=1.10.0"
 typing-extensions = "*"
-xeger = "*"
 
 [tool.poetry.group.dev.dependencies]
 email-validator = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-factories"
-version = "1.13.0"
+version = "1.14.0"
 description = "Mock data generation for pydantic based models and python dataclasses"
 authors = ["Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 maintainers = [

--- a/tests/test_refex_factory.py
+++ b/tests/test_refex_factory.py
@@ -163,7 +163,7 @@ def test_incoherent_limit_and_qualifier(limit: int) -> None:
 
 
 @pytest.mark.parametrize("seed", [777, 1234, 369, 8031])
-def test_xeger_object_seeding(seed: int) -> None:
+def test_regex_factory_object_seeding(seed: int) -> None:
     xg1 = RegexFactory(seed=seed)
     string1 = xg1(r"\w{3,4}")
 
@@ -173,7 +173,7 @@ def test_xeger_object_seeding(seed: int) -> None:
     assert string1 == string2
 
 
-def test_xeger_random_instance() -> None:
+def test_regex_factorx_random_instance() -> None:
     xg1 = RegexFactory()
     xg_random = xg1._random
 

--- a/tests/test_refex_factory.py
+++ b/tests/test_refex_factory.py
@@ -1,0 +1,192 @@
+"""The tests in this file have been adapted from:
+
+https://github.com/crdoconnor/xeger/blob/master/xeger/tests/test_xeger.py
+"""
+
+import re
+from typing import TYPE_CHECKING, Union
+
+import pytest
+
+from pydantic_factories.value_generators.regex import RegexFactory
+
+if TYPE_CHECKING:
+    from re import Pattern
+
+
+def match(pattern: Union[str, "Pattern"]) -> None:
+    for _ in range(100):
+        assert re.match(pattern, RegexFactory()(pattern))
+
+
+def test_single_dot() -> None:
+    """Verify that the dot character produces only a single character."""
+    match(r"^.$")
+
+
+def test_dot() -> None:
+    """Verify that the dot character doesn't produce newlines.
+
+    See: https://bitbucket.org/leapfrogdevelopment/rstr/issue/1/
+    """
+    for _ in range(100):
+        match(r".+")
+
+
+def test_date() -> None:
+    match(r"^([1-9]|0[1-9]|[12][0-9]|3[01])\D([1-9]|0[1-9]|1[012])\D(19[0-9][0-9]|20[0-9][0-9])$")
+
+
+def test_up_to_closing_tag() -> None:
+    match(r"([^<]*)")
+
+
+def test_ipv4() -> None:
+    match(r"^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]){3}$")
+
+
+def test_year_1900_2099() -> None:
+    match(r"^(19|20)[\d]{2,2}$")
+
+
+def test_positive_or_negative_number() -> None:
+    match(r"^-{0,1}\d*\.{0,1}\d+$")
+
+
+def test_positive_integers() -> None:
+    match(r"^\d+$")
+
+
+def test_email_complicated() -> None:
+    match(r'^([0-9a-zA-Z]([\+\-_\.][0-9a-zA-Z]+)*)+"@(([0-9a-zA-Z][-\w]*[0-9a-zA-Z]*\.)+[a-zA-Z0-9]{2,17})$')
+
+
+def test_email() -> None:
+    match(r"(.*?)\@(.*?)\.(.*?)")
+
+
+def test_alpha() -> None:
+    match(r"[:alpha:]")
+
+
+def test_zero_or_more_anything_non_greedy() -> None:
+    match(r"(.*?)")
+
+
+def test_literals() -> None:
+    match(r"foo")
+
+
+def test_digit() -> None:
+    match(r"\d")
+
+
+def test_nondigits() -> None:
+    match(r"\D")
+
+
+def test_literal_with_repeat() -> None:
+    match(r"A{3}")
+
+
+def test_literal_with_range_repeat() -> None:
+    match(r"A{2, 5}")
+
+
+def test_word() -> None:
+    match(r"\w")
+
+
+def test_nonword() -> None:
+    match(r"\W")
+
+
+def test_or() -> None:
+    match(r"foo|bar")
+
+
+def test_or_with_subpattern() -> None:
+    match(r"(foo|bar)")
+
+
+def test_range() -> None:
+    match(r"[A-F]")
+
+
+def test_character_group() -> None:
+    match(r"[ABC]")
+
+
+def test_caret() -> None:
+    match(r"^foo")
+
+
+def test_dollarsign() -> None:
+    match(r"foo$")
+
+
+def test_not_literal() -> None:
+    match(r"[^a]")
+
+
+def test_negation_group() -> None:
+    match(r"[^AEIOU]")
+
+
+def test_lookahead() -> None:
+    match(r"foo(?=bar)")
+
+
+def test_lookbehind() -> None:
+    pattern = r"(?<=foo)bar"
+    assert re.search(pattern, RegexFactory()(pattern))
+
+
+def test_backreference() -> None:
+    match(r"(foo|bar)baz\1")
+
+
+def test_zero_or_more_greedy() -> None:
+    match(r"a*")
+    match(r"(.*)")
+
+
+def test_zero_or_more_non_greedy() -> None:
+    match(r"a*?")
+
+
+@pytest.mark.parametrize("limit", range(5))
+def test_incoherent_limit_and_qualifier(limit: int) -> None:
+    r = RegexFactory(limit=limit)
+    o = r(r"a{2}")
+    assert len(o) == 2
+
+
+@pytest.mark.parametrize("seed", [777, 1234, 369, 8031])
+def test_xeger_object_seeding(seed: int) -> None:
+    xg1 = RegexFactory(seed=seed)
+    string1 = xg1(r"\w{3,4}")
+
+    xg2 = RegexFactory(seed=seed)
+    string2 = xg2(r"\w{3,4}")
+
+    assert string1 == string2
+
+
+def test_xeger_random_instance() -> None:
+    xg1 = RegexFactory()
+    xg_random = xg1._random
+
+    xg2 = RegexFactory()
+    xg2._random = xg_random
+
+    assert xg1._random == xg2._random
+    # xg_random is used by both, so if we give
+    # the same seed, the result should be the same
+
+    xg_random.seed(90)
+    string1 = xg1(r"\w\d\w")
+    xg_random.seed(90)
+    string2 = xg2(r"\w\d\w")
+
+    assert string1 == string2


### PR DESCRIPTION
This PR replace `Xeger`, which has not been updated for 2 years and is not compatible with py 3.11. It does additional housekeeping. 