### PR TITLE
Fix error when building Pydantic models with nested Dict field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+[1.13.1]
+
+- fix `ModelFactory` build ignore error when specifying an explicit dict for a nested `Dict` field. @anthonyh209
 
 [1.13.0]
 

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -84,7 +84,7 @@ from pydantic import (
     create_model_from_typeddict,
 )
 from pydantic.color import Color
-from pydantic.fields import SHAPE_MAPPING
+from pydantic.fields import SHAPE_DICT, SHAPE_MAPPING
 from typing_extensions import _TypedDictMeta  # type: ignore
 from typing_extensions import TypeGuard, get_args, is_typeddict
 
@@ -215,7 +215,7 @@ class ModelFactory(Generic[T]):
         Returns:
             A boolean determining whether the given field value is a pydantic model with missing kwargs.
         """
-        if model_field.shape != SHAPE_MAPPING and is_pydantic_model(model_field.type_):
+        if model_field.shape not in (SHAPE_DICT, SHAPE_MAPPING) and is_pydantic_model(model_field.type_):
             field_kwargs = kwargs.get(field_name)
 
             if isinstance(field_kwargs, list):

--- a/tests/test_factory_child_models.py
+++ b/tests/test_factory_child_models.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel
 
@@ -179,9 +179,34 @@ def test_factory_not_ok() -> None:
 
     nested = NestedSchema(v="hello", z=0)
     some_dict = {"test": "fine"}
-    upper = UpperSchemaFactory.build(b=some_dict, nested={"nested_key": nested})
+    upper = UpperSchemaFactory.build(
+        b=some_dict, 
+        nested={"nested_key": nested},
+    )
 
     assert upper.b["test"] == "fine"
     assert "nested_key" in upper.nested
     assert upper.nested["nested_key"].v == nested.v
+    assert upper.nested["nested_key"].z == nested.z
+    assert "nested_dict" in upper.nested
+
+
+def test_factory_with_nested_dict() -> None:
+    """Given a Pydantic Model with nested Dict field, When I build the model
+    using the factory passing only partial attributes, Then the model is
+    correctly built."""
+
+    class NestedSchema(BaseModel):
+        z: int
+
+    class UpperSchema(BaseModel):
+        nested: Dict[str, NestedSchema]
+
+    class UpperSchemaFactory(ModelFactory):
+        __model__ = UpperSchema
+
+    nested = NestedSchema(z=0)
+    upper = UpperSchemaFactory.build(nested={"nested_key": nested})
+
+    assert "nested_key" in upper.nested
     assert upper.nested["nested_key"].z == nested.z


### PR DESCRIPTION
This aims to solve a very similar to the previously reported issue https://github.com/starlite-api/pydantic-factories/issues/61.

This PR aims to fix the same error for the Dict field. An example case is shown below

```
class NestedSchema(BaseModel):
    z: int


class UpperSchema(BaseModel):
    nested: Mapping[str, NestedSchema]


class NestedSchemaFactory(ModelFactory):
    __model__ = NestedSchema


class UpperSchemaFactory(ModelFactory):
    __model__ = UpperSchema
```

This will not work as intended and the explicitly set nested field will be respected during the build call
```
def test_dict_factory_not_ok():
    nested = NestedSchema(z=0)
    upper = UpperSchemaFactory.build(nested={"nested": nested})
```