### PR TITLE
Improve typing for internal number generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
         additional_dependencies:
           [pydantic, faker, pytest, hypothesis, odmantic, ormar, beanie]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.280
+    rev: v1.1.281
     hooks:
       - id: pyright
         exclude: "extension"

--- a/pydantic_factories/value_generators/constrained_number.py
+++ b/pydantic_factories/value_generators/constrained_number.py
@@ -1,7 +1,7 @@
 import random
 import sys
 from decimal import Decimal
-from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Dict, Optional, Protocol, Tuple, Type, TypeVar, cast
 
 from pydantic_factories.exceptions import ParameterError
 from pydantic_factories.utils import (
@@ -10,6 +10,11 @@ from pydantic_factories.utils import (
 )
 
 T = TypeVar("T", Decimal, int, float)
+
+
+class NumberGeneratorProtocol(Protocol[T]):
+    def __call__(self, minimum: Optional[T] = None, maximum: Optional[T] = None) -> T:
+        ...
 
 
 def get_increment(t_type: Type[T]) -> T:
@@ -82,13 +87,13 @@ def generate_constrained_number(
     minimum: Optional[T],
     maximum: Optional[T],
     multiple_of: Optional[T],
-    method: Callable,
+    method: NumberGeneratorProtocol[T],
 ) -> T:
     """Generates a constrained number, output depends on the passed in
     callbacks."""
     if minimum is not None and maximum is not None:
         if multiple_of is None:
-            return cast("T", method(minimum, maximum))
+            return method(minimum, maximum)
         if multiple_of >= minimum:
             return multiple_of
         result = minimum
@@ -97,4 +102,4 @@ def generate_constrained_number(
         return result
     if multiple_of is not None:
         return multiple_of
-    return cast("T", method())
+    return method()

--- a/tests/constraints/test_decimal_constraints.py
+++ b/tests/constraints/test_decimal_constraints.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, cast
 
 import pytest
 from hypothesis import given
@@ -52,7 +52,7 @@ def test_handle_constrained_decimal_length_validation() -> None:
 def test_handle_constrained_decimal_handles_max_digits(max_digits: int) -> None:
     if max_digits > 0:
         result = handle_constrained_decimal(create_constrained_field(max_digits=max_digits))
-        assert len(result.as_tuple().digits) - abs(result.as_tuple().exponent) <= max_digits
+        assert len(result.as_tuple().digits) - abs(cast("int", result.as_tuple().exponent)) <= max_digits  # type: ignore[redundant-cast]
     else:
         with pytest.raises(ParameterError):
             handle_constrained_decimal(create_constrained_field(max_digits=max_digits))
@@ -61,7 +61,7 @@ def test_handle_constrained_decimal_handles_max_digits(max_digits: int) -> None:
 @given(integers(min_value=0, max_value=100))
 def test_handle_constrained_decimal_handles_decimal_places(decimal_places: int) -> None:
     result = handle_constrained_decimal(create_constrained_field(decimal_places=decimal_places))
-    assert abs(result.as_tuple().exponent) <= decimal_places
+    assert abs(cast("int", result.as_tuple().exponent)) <= decimal_places  # type: ignore[redundant-cast]
 
 
 @given(integers(min_value=0, max_value=100), integers(min_value=1, max_value=100))
@@ -70,7 +70,7 @@ def test_handle_constrained_decimal_handles_max_digits_and_decimal_places(max_di
         result = handle_constrained_decimal(
             create_constrained_field(max_digits=max_digits, decimal_places=decimal_places)
         )
-        assert len(result.as_tuple().digits) - abs(result.as_tuple().exponent) <= max_digits
+        assert len(result.as_tuple().digits) - abs(cast("int", result.as_tuple().exponent)) <= max_digits  # type: ignore[redundant-cast]
     else:
         with pytest.raises(ParameterError):
             handle_constrained_decimal(create_constrained_field(max_digits=max_digits, decimal_places=decimal_places))
@@ -211,7 +211,7 @@ def test_handle_decimal_length() -> None:
 
     assert isinstance(result, Decimal)
     assert len(result.as_tuple().digits) == 5
-    assert abs(result.as_tuple().exponent) == 2
+    assert abs(cast("int", result.as_tuple().exponent)) == 2  # type: ignore[redundant-cast]
 
     # here decimal places should determine max length
     max_digits = 10
@@ -220,7 +220,7 @@ def test_handle_decimal_length() -> None:
     result = handle_decimal_length(decimal, decimal_places, max_digits)
     assert isinstance(result, Decimal)
     assert len(result.as_tuple().digits) == 8
-    assert abs(result.as_tuple().exponent) == 5
+    assert abs(cast("int", result.as_tuple().exponent)) == 5  # type: ignore[redundant-cast]
 
     # here digits determine decimal length
     max_digits = 10
@@ -229,7 +229,7 @@ def test_handle_decimal_length() -> None:
     result = handle_decimal_length(decimal, decimal_places, max_digits)
     assert isinstance(result, Decimal)
     assert len(result.as_tuple().digits) == 10
-    assert abs(result.as_tuple().exponent) == 7
+    assert abs(cast("int", result.as_tuple().exponent)) == 7  # type: ignore[redundant-cast]
 
     # here decimal places determine decimal length
     max_digits = None  # type: ignore
@@ -238,7 +238,7 @@ def test_handle_decimal_length() -> None:
     result = handle_decimal_length(decimal, decimal_places, max_digits)
     assert isinstance(result, Decimal)
     assert len(result.as_tuple().digits) == 8
-    assert abs(result.as_tuple().exponent) == 5
+    assert abs(cast("int", result.as_tuple().exponent)) == 5  # type: ignore[redundant-cast]
 
     # here max_decimals is below 0
     decimal = Decimal("99.99")
@@ -246,7 +246,7 @@ def test_handle_decimal_length() -> None:
     result = handle_decimal_length(decimal, decimal_places, max_digits)
     assert isinstance(result, Decimal)
     assert len(result.as_tuple().digits) == 1
-    assert result.as_tuple().exponent == 0
+    assert cast("int", result.as_tuple().exponent) == 0  # type: ignore[redundant-cast]
 
 
 def test_zero_to_one_range() -> None:


### PR DESCRIPTION
I had to keep pyright at 1.1.280 in #126 because 1.1.281 didn't type check `generate_constrained_number` with Callable.

This PR improves typing of the function and upgades pyright to the latest version.