### PR TITLE
Do deepcopy for ormar fields we mark as required

### DIFF
--- a/pydantic_factories/extensions/ormar_orm.py
+++ b/pydantic_factories/extensions/ormar_orm.py
@@ -2,6 +2,7 @@ import random
 from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import BaseModel
+from pydantic.utils import smart_deepcopy
 
 from pydantic_factories.factory import ModelFactory
 from pydantic_factories.utils import is_pydantic_model, is_union
@@ -20,7 +21,10 @@ class OrmarModelFactory(ModelFactory[Model]):  # pragma: no cover # type: ignore
     def get_field_value(cls, model_field: "ModelField", field_parameters: Union[dict, list, None] = None) -> Any:
         """We need to handle here both choices and the fact that ormar sets values to be optional."""
 
-        model_field.required = True
+        if not model_field.required:
+            model_field = smart_deepcopy(model_field)
+            model_field.required = True
+
         # check if this is a RelationShip field
         if (
             is_union(model_field=model_field)


### PR DESCRIPTION
Closes #128 

For some reason when setting `model_field.required` other attributes are resetted. So the best solution I was to able to come up is using deepcopy on `model_field` if we are going to set `required` to True. Everything else I tried failed on other stages damaging the initial model.